### PR TITLE
Replace pkg_resources with importlib.metadata; bump minor version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyramid-helloworld"
-version = "1.0.0"
+version = "1.1.0"
 description = "Hello World web app using pyramid."
 authors = ["Guillaume Gauvrit <guillaume@gauvr.it>"]
 license = "BSD-derived"
@@ -10,7 +10,9 @@ include = ["development.yaml"]
 [tool.poetry.dependencies]
 python = "^3.7"
 celery = { version = "^5", optional = true}
-plaster-yaml = "^0.1.3"
+# See: https://pypi.org/project/backports.entry-points-selectable
+importlib_metadata = { version = ">=3.6", python = "<3.10" }
+plaster-yaml = "^0.2.0"
 pyramid = ">1.10, ^2.0"
 waitress = "^2.0.0"
 

--- a/pyramid_helloworld/__init__.py
+++ b/pyramid_helloworld/__init__.py
@@ -1,10 +1,20 @@
-import pkg_resources
+import sys
+
+if sys.version_info < (3, 10):
+    import importlib_metadata
+
+    class importlib:
+        pass
+
+    setattr(importlib, "metadata", importlib_metadata)
+else:
+    import importlib.metadata
 
 from pyramid.config import Configurator
 from pyramid.response import Response
 from pyramid.router import Router
 
-__version__ = pkg_resources.get_distribution("pyramid-helloworld").version
+__version__ = importlib.metadata.version("pyramid-helloworld")
 
 from .backend import app
 from . import tasks


### PR DESCRIPTION
pkg_resources is depreciated.

I changed the required plaster-yaml version number to correspond with the bumped version number in a pull request for that package that also removes pkg_resources.  (plaster-yaml pull request #3)  This removes some deprecation warnings from the regression test run.

Notes on backported standard library modules:

I like to conditionally import backported standard library modules.  I like to see the version number in the code so the version number is explicit, and in an obvious place.  That way it is clear when it is time to remove the conditional import and just use the standard library.

I find that creating a class to act as the top-level module in the module path, when the backported library is not top-level, helps with mocks when unit testing.